### PR TITLE
Ganglia reporter

### DIFF
--- a/metrics-clojure-core/project.clj
+++ b/metrics-clojure-core/project.clj
@@ -1,6 +1,7 @@
 (defproject metrics-clojure "0.7.1"
   :description "A Clojure façade for Coda Hale's metrics library."
   :dependencies [[org.clojure/clojure "[1.2.1,1.3.0]"]
-                 [com.yammer.metrics/metrics-core "2.0.1"]]
+                 [com.yammer.metrics/metrics-core "2.0.1"]
+                 [com.yammer.metrics/metrics-ganglia "2.0.1"]]
   :repositories {"repo.codahale.com" "http://repo.codahale.com"}
   :warn-on-reflection true)

--- a/metrics-clojure-core/src/metrics/core.clj
+++ b/metrics-clojure-core/src/metrics/core.clj
@@ -1,7 +1,7 @@
 (ns metrics.core
   (:use [metrics.utils :only (metric-name)])
   (:import (com.yammer.metrics Metrics))
-  (:import (com.yammer.metrics.reporting ConsoleReporter))
+  (:import (com.yammer.metrics.reporting ConsoleReporter GangliaReporter))
   (:import (java.util.concurrent TimeUnit)))
 
 
@@ -17,3 +17,7 @@
   (ConsoleReporter/enable seconds TimeUnit/SECONDS))
 
 
+(defn report-to-ganglia
+  "Report all metrics to ganglia every few minutes."
+  [minutes host port]
+  (GangliaReporter/enable minutes TimeUnit/MINUTES host port))


### PR DESCRIPTION
Added a dependency on the `metrics-ganglia` module and a `report-to-ganglia` clojure fn that enables a `GangliaReporter`.

Thanks for putting this together! I'm excited to be using metrics-clojure.
