### PR TITLE
Don’t force URIs to end with a slash

### DIFF
--- a/metrics-clojure-ring/src/metrics/ring/expose.clj
+++ b/metrics-clojure-ring/src/metrics/ring/expose.clj
@@ -85,9 +85,10 @@
 (defn expose-metrics-as-json
   ([handler] (expose-metrics-as-json handler "/metrics"))
   ([handler uri]
-   (let [uri (sanitize-uri uri)]
+   (let [request-uri (:uri request)]
      (fn [request]
-       (if (.startsWith (:uri request) uri)
+       (if (or (.startsWith request-uri (sanitize-uri uri))
+               (= request-uri uri))
          (metrics-json request)
          (handler request))))))
 


### PR DESCRIPTION
All our in-house services expose their metrics under `/metrics`, but `expose-metrics-as-json` forces a trailing slash onto whatever URI it takes, which means we have to make an exception for services using `metrics-clojure-ring`. Because `metrics-json` is private, I can't add another handler which lets me specify the URI I need.

The attached pull request removes the code which forces metrics URIs to end with a trailing slash. This will break backwards compatibility with tools which expect metrics to be exposed under `/metrics/`; I would be happy to change the default to that to avoid breakage, if that is something you'd like.
