### PR TITLE
Update to Metrics 2.2.0. Add a `metrics.meters/count` fn.

### DIFF
--- a/metrics-clojure-core/project.clj
+++ b/metrics-clojure-core/project.clj
@@ -1,6 +1,6 @@
 (defproject metrics-clojure "0.9.2"
   :description "A Clojure façade for Coda Hale's metrics library."
   :dependencies [[org.clojure/clojure "[1.2.1,1.4.0]"]
-                 [com.yammer.metrics/metrics-core "2.0.1"]]
+                 [com.yammer.metrics/metrics-core "2.2.0"]]
   :repositories {"repo.codahale.com" "http://repo.codahale.com"}
   :warn-on-reflection true)

--- a/metrics-clojure-core/src/metrics/meters.clj
+++ b/metrics-clojure-core/src/metrics/meters.clj
@@ -49,6 +49,9 @@
 (defn rate-mean [^Meter m]
   (.meanRate m))
 
+(defn count [^Meter m]
+  (.count m))
+
 
 ; Write -----------------------------------------------------------------------
 (defn mark!

--- a/metrics-clojure-core/test/metrics/test/meters.clj
+++ b/metrics-clojure-core/test/metrics/test/meters.clj
@@ -43,3 +43,9 @@
     (meters/mark! m 20000)
     (Thread/sleep 8000)
     (is (every? #(> % 0.0) (vals (meters/rates m))))))
+
+(deftest test-count
+  (let [m (meters/meter ["test" "meters" "test-count"] "test-events")]
+    (is (zero? (meters/count m)))
+    (meters/mark! m)
+    (is (= 1 (meters/count m)))))


### PR DESCRIPTION
This updates metrics-clojure to the current stable Metrics version, and adds a fn to return the number of times a meter has been marked to `metrics.meters`. The name `count` conflicts with clojure.core; I'd be open to changing that, but I'm not sure what a good alternative would be.
