### PR TITLE
Don't depend on version range

### DIFF
--- a/metrics-clojure-core/project.clj
+++ b/metrics-clojure-core/project.clj
@@ -1,6 +1,6 @@
 (defproject metrics-clojure "0.9.2"
   :description "A Clojure façade for Coda Hale's metrics library."
-  :dependencies [[org.clojure/clojure "[1.2.1,1.4.0]"]
+  :dependencies [[org.clojure/clojure "1.2.1"]
                  [com.yammer.metrics/metrics-core "2.0.1"]]
   :repositories {"repo.codahale.com" "http://repo.codahale.com"}
   :warn-on-reflection true)


### PR DESCRIPTION
Just the number means "minimum version" anyway.
With the `[1.2.1,1.4.0]` range, upgrading to 1.5.0 makes Leiningen download 1.2.1…
