### PR TITLE
Update to Cheshire 5.0.2.

### DIFF
--- a/metrics-clojure-ring/project.clj
+++ b/metrics-clojure-ring/project.clj
@@ -1,4 +1,4 @@
 (defproject metrics-clojure-ring "0.9.2"
   :description "Various things gluing together metrics-clojure and ring."
-  :dependencies [[cheshire "2.2.2"]
+  :dependencies [[cheshire "5.0.2"]
                  [metrics-clojure "0.9.2"]])


### PR DESCRIPTION
I had issues with the current release of `metrics-clojure-ring` because of the very old version of cheshire causing dependency conflicts.

This one-liner updates it to the current version.
