### PR TITLE
Don't use version ranges

### DIFF
--- a/metrics-clojure-core/project.clj
+++ b/metrics-clojure-core/project.clj
@@ -1,6 +1,6 @@
 (defproject metrics-clojure "0.9.2"
   :description "A Clojure façade for Coda Hale's metrics library."
-  :dependencies [[org.clojure/clojure "[1.2.1,1.4.0]"]
+  :dependencies [[org.clojure/clojure "1.5.1"]
                  [com.yammer.metrics/metrics-core "2.0.1"]]
   :repositories {"repo.codahale.com" "http://repo.codahale.com"}
   :warn-on-reflection true)


### PR DESCRIPTION
Version ranges are generally frowned upon
in the Clojure community.

Depending on "1.5.1" means "1.5.1 unless other version
is specified". This way projects that need to use
a different version will be able to do so easily.
