### PR TITLE
Add support for TRACE, CONNECT and unrecognised verbs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ pom.xml
 .lein-failures
 .lein-deps-sum
 docs/build
-target/*
+target

--- a/metrics-clojure-ring/project.clj
+++ b/metrics-clojure-ring/project.clj
@@ -1,4 +1,5 @@
 (defproject metrics-clojure-ring "1.1.0-SNAPSHOT"
   :description "Various things gluing together metrics-clojure and ring."
   :dependencies [[cheshire "5.0.2"]
-                 [metrics-clojure "1.1.0-SNAPSHOT"]])
+                 [metrics-clojure "1.1.0-SNAPSHOT"]]
+  :profiles {:dev {:dependencies [[ring "1.2.0"]]}})


### PR DESCRIPTION
We're currently seeing an exception from the metrics.ring.instrument namespace whenever we receive a request using the HTTP verbs TRACE or CONNECT:

```
java.lang.NullPointerException: null
    at metrics.ring.instrument$instrument$fn__4119.invoke(instrument.clj:43)
```

This change adds these two verbs, but also ensures that any more unrecognised verbs can be handled, by logging them all under an 'OTHER' metric.
