### PR TITLE
fix for Timer mean (not rate)

### DIFF
--- a/metrics-clojure-core/src/metrics/timers.clj
+++ b/metrics-clojure-core/src/metrics/timers.clj
@@ -57,7 +57,7 @@
 
 (defn mean
   [^Timer t]
-  (.getMeanRate t))
+  (.getMean (snapshot t)))
 
 (defn std-dev
   [^Timer t]


### PR DESCRIPTION
`mean` should be the mean of the samples (.getMean), not the rate-mean (.getMeanRate)
