### PR TITLE
adaptations for changes in underlying metrics API

### DIFF
--- a/metrics-clojure-core/src/metrics/reporters/console.clj
+++ b/metrics-clojure-core/src/metrics/reporters/console.clj
@@ -1,16 +1,16 @@
 (ns metrics.reporters.console
   "Console reporting"
+  (:require [metrics.core  :refer [default-registry]])
   (:import java.util.concurrent.TimeUnit
-           [com.codahale.metrics Metrics MetricsRegistry ConsoleReporter ConsoleReporter$Builder Clock MetricsFilter]
+           [com.codahale.metrics Metric MetricRegistry ConsoleReporter Clock MetricFilter]
            java.io.PrintStream
            java.util.Locale))
 
 (defn ^ConsoleReporter reporter
   ([opts]
-   (reporter (Metrics/defaultRegistry)
-             opts))
-  ([^MetricsRegistry reg opts]
-   (let [b (ConsoleReporter$Builder. reg)]
+   (reporter default-registry opts))
+  ([^MetricRegistry reg opts]
+   (let [b (ConsoleReporter/forRegistry reg)]
      (when-let [^PrintStream s (:stream opts)]
        (.outputTo b s))
      (when-let [^Locale l (:locale opts)]
@@ -21,7 +21,7 @@
        (.convertRatesTo b ru))
      (when-let [^TimeUnit du (:duration-unit opts)]
        (.convertDurationsTo b du))
-     (when-let [^MetricsFilter f (:filter opts)]
+     (when-let [^MetricFilter f (:filter opts)]
        (.filter b f))
      (.build b))))
 

--- a/metrics-clojure-core/test/metrics/reporters/test/console_test.clj
+++ b/metrics-clojure-core/test/metrics/reporters/test/console_test.clj
@@ -1,0 +1,7 @@
+(ns metrics.reporters.test.console-test
+  (:require [metrics.reporters.console :refer [reporter]])
+  (:use [clojure.test]))
+
+(deftest test-console-reporter
+  "Checks that the console reporter can be instantiated."
+  (is (reporter {})))

--- a/metrics-clojure-ring/src/metrics/ring/expose.clj
+++ b/metrics-clojure-ring/src/metrics/ring/expose.clj
@@ -1,5 +1,5 @@
 (ns metrics.ring.expose
-  (:import (com.yammer.metrics.core Gauge Timer Counter Histogram Meter))
+  (:import (com.codahale.metrics Gauge Timer Counter Histogram Meter))
   (:require [metrics.gauges :as gauges]
             [metrics.meters :as meters]
             [metrics.histograms :as histograms]

--- a/metrics-clojure-ring/test/metrics/test/expose_test.clj
+++ b/metrics-clojure-ring/test/metrics/test/expose_test.clj
@@ -1,0 +1,10 @@
+(ns metrics.test.expose-test
+  (:require [clojure.test :refer :all]
+            [metrics.ring.expose :refer [expose-metrics-as-json]])
+  (:import [com.codahale.metrics MetricRegistry]))
+
+(deftest test-expose-metrics-as-json
+  "Ensure that the handler can be called without blowing up."
+  (expose-metrics-as-json (constantly nil)))
+
+


### PR DESCRIPTION
It looks like a couple of namespaces where missed out when moving to the new metrics API.  This pull request updates those namespaces and adds trivial tests to ensure that they compile.
