### PR TITLE
Add a couple of places where we can default to using default-registry

### DIFF
--- a/metrics-clojure-jvm/src/metrics/jvm/core.clj
+++ b/metrics-clojure-jvm/src/metrics/jvm/core.clj
@@ -2,7 +2,7 @@
   (:import (com.codahale.metrics MetricRegistry JvmAttributeGaugeSet)
            (com.codahale.metrics.jvm ThreadStatesGaugeSet GarbageCollectorMetricSet FileDescriptorRatioGauge
                                      MemoryUsageGaugeSet))
-  (:require [metrics.core :refer [add-metric]]))
+  (:require [metrics.core :refer [add-metric default-registry]]))
 
 (defn register-jvm-attribute-gauge-set
   ([^MetricRegistry reg]
@@ -35,10 +35,12 @@
    (add-metric reg title (new ThreadStatesGaugeSet))))
 
 (defn instrument-jvm
-  [^MetricRegistry reg]
-  (doseq [register-metric-set [register-jvm-attribute-gauge-set
-                               register-memory-usage-gauge-set
-                               register-file-descriptor-ratio-gauge-set
-                               register-garbage-collector-metric-set
-                               register-thread-state-gauge-set]]
-    (register-metric-set reg)))
+  ([]
+   (instrument-jvm default-registry))
+  ([^MetricRegistry reg]
+   (doseq [register-metric-set [register-jvm-attribute-gauge-set
+                                register-memory-usage-gauge-set
+                                register-file-descriptor-ratio-gauge-set
+                                register-garbage-collector-metric-set
+                                register-thread-state-gauge-set]]
+     (register-metric-set reg))))

--- a/metrics-clojure-ring/src/metrics/ring/instrument.clj
+++ b/metrics-clojure-ring/src/metrics/ring/instrument.clj
@@ -1,5 +1,6 @@
 (ns metrics.ring.instrument
-  (:require [metrics.counters :refer (counter inc! dec!)]
+  (:require [metrics.core :refer [default-registry]]
+            [metrics.counters :refer (counter inc! dec!)]
             [metrics.meters :refer (meter mark!)]
             [metrics.timers :refer (timer time!)])
   (:import [com.codahale.metrics MetricRegistry]))
@@ -15,6 +16,8 @@
   This middleware should be added as late as possible (nearest to the outside of
   the \"chain\") for maximum effect.
   "
+  ([handler]
+   (instrument handler default-registry))
   ([handler ^MetricRegistry reg]
    (let [active-requests (counter reg ["ring" "requests" "active"])
          requests (meter reg ["ring" "requests" "rate"])


### PR DESCRIPTION
While attempting to migrate an existing project to use the latest beta of metrics-clojure I found a couple of places where we can hopefully use the `default-registry` to ease the migration.
