### PR TITLE
Handle title array with three items as a special case

### DIFF
--- a/metrics-clojure-core/src/metrics/core.clj
+++ b/metrics-clojure-core/src/metrics/core.clj
@@ -17,8 +17,9 @@
     (MetricRegistry/name
      ^String (first title)
      ^"[Ljava.lang.String;" (into-array String
-                                        [(second title)
-                                         (last title)]))))
+                                        (if (= 3 (count title))
+                                          [(second title) (last title)]
+                                          (rest title))))))
 
 (defn add-metric
   "Add a metric with the given title."


### PR DESCRIPTION
This is an attempt to prevent the duplicated parts in JVM metric names mentioned in #39.

It's a pretty naïve change for the case where the title doesn't contain three things but it should at least keep everyone's metrics working as they currently do.
