### PR TITLE
Use a valid :tag for default-registry (was breaking reflection)

### DIFF
--- a/metrics-clojure-core/src/metrics/core.clj
+++ b/metrics-clojure-core/src/metrics/core.clj
@@ -1,7 +1,7 @@
 (ns metrics.core
   (:import [com.codahale.metrics MetricRegistry Metric]))
 
-(def ^{:tag "MetricRegistry" :doc "Default registry used by public API functions when no explicit registry argument is given"}
+(def ^{:tag MetricRegistry :doc "Default registry used by public API functions when no explicit registry argument is given"}
   default-registry
   (MetricRegistry.))
 

--- a/metrics-clojure-core/test/metrics/test/core_test.clj
+++ b/metrics-clojure-core/test/metrics/test/core_test.clj
@@ -1,0 +1,7 @@
+(ns metrics.test.core-test
+  (:require [metrics.core :as core]
+            [clojure.test :refer :all]))
+
+(deftest regression-default-registry-tag
+  (testing "Ensure default-registry no longer has invalid reflection :tag"
+    (.getMeters core/default-registry)))


### PR DESCRIPTION
Bug was introduced in 2ea88520dea284f3f5ca5395fb8a30f0db9e7fb0 (present on current master and in 2.1.0; theoretically present in all 2.x.x versions.)
