### PR TITLE
Updated docs and doc strings, removed outdated docs.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -10,7 +10,7 @@ Installation
 
 Add this to your `project.clj`'s dependencies:
 
-    [metrics-clojure "2.2.0"]
+    [metrics-clojure "2.3.0"]
 
 That's it.
 
@@ -26,4 +26,3 @@ More Information
 * Source (Git): <http://github.com/sjl/metrics-clojure/>
 * Issues: <http://github.com/sjl/metrics-clojure/issues/>
 * License: MIT/X11
-

--- a/docs/source/metrics/counters.rst
+++ b/docs/source/metrics/counters.rst
@@ -32,6 +32,11 @@ Create your counter::
     (def reg (new-registry))
     (def users-connected (counter reg "users-connected"))
 
+The ``counter`` function is idempotent, which means that you don't
+need to keep a local reference to the counter. Once a counter has been
+registered, a call to ``(counter reg "users-connected")`` will return
+the existing counter.
+
 .. _counters/defcounter:
 
 You can also use the ``defcounter`` macro to create a counter and bind it to a var
@@ -62,6 +67,11 @@ omit it to increment by 1::
     (inc! users-connected)
     (inc! users-connected 2)
 
+Or if you haven't held a reference to ``users-connected``, you can do the following::
+
+    (inc! (counter reg "users-connected"))
+    (inc! (counter reg "users-connected") 2)
+
 .. _counters/dec!:
 
 ``dec!``
@@ -74,6 +84,11 @@ omit it to decrement by 1::
 
     (dec! users-connected)
     (dec! users-connected 2)
+
+Or if you haven't held a reference to ``users-connected``, you can do the following::
+
+    (dec! (counter reg "users-connected"))
+    (dec! (counter reg "users-connected") 2)
 
 Reading
 -------
@@ -90,3 +105,10 @@ You can get the current value of a counter with ``value``::
     (require '[metrics.counters :refer [value]])
 
     (value users-connected)
+
+Or if you haven't held a reference to ``users-connected``, you can do the following::
+
+    (value (counter reg "users-connected"))
+
+The counter will be created and return the default value if it hasn't
+been registered before.

--- a/docs/source/metrics/histograms.rst
+++ b/docs/source/metrics/histograms.rst
@@ -43,13 +43,12 @@ Create your histogram::
     (def reg (new-registry))
 
     (def search-results-returned
-      (histogram "search-results-returned"))
+      (histogram reg "search-results-returned"))
 
-You can create an unbiased histogram by passing an extra boolean argument
-(though you probably don't want to)::
-
-    (def search-results-returned-biased
-      (histogram reg "search-results-returned-unbiased" false))
+The ``histogram`` function is idempotent, which means that you don't
+need to keep a local reference to the histogram. Once a histogram has been
+registered, a call to ``(histogram reg "search-results-returned")`` will return
+the existing histogram.
 
 .. _histograms/defhistogram:
 
@@ -79,6 +78,10 @@ Update the histogram when you have a new value to record with ``update!``::
     (require '[metrics.histograms :refer [update!]])
 
     (update! search-results-returned 10)
+
+Or if you haven't held a reference to ``search-results-returned``, you can do the following::
+
+    (update! (histogram reg "search-results-returned") 10)
 
 Reading
 -------
@@ -110,6 +113,15 @@ value for that percentile.  In this example:
 * 95% of searches returned 299 or fewer results.
 * ... etc.
 
+Or if you haven't held a reference to ``search-results-returned``, you can do the following::
+
+    (percentiles (histogram reg "search-results-returned"))
+    => { 0.75   180
+         0.95   299
+         0.99   300
+         0.999  340
+         1.0   1345 }
+
 If you want a different set of percentiles just pass them as a sequence::
 
     (require '[metrics.histograms :refer [percentiles]])
@@ -131,6 +143,11 @@ histogram::
     (number-recorded search-results-returned)
     => 12882
 
+Or if you haven't held a reference to ``search-results-returned``, you can do the following::
+
+    (number-recorded (histogram reg "search-results-returned"))
+    => 12882
+
 .. _histograms/smallest:
 
 ``smallest``
@@ -142,6 +159,11 @@ histogram::
     (require '[metrics.histograms :refer [smallest]])
 
     (smallest search-results-returned)
+    => 4
+
+Or if you haven't held a reference to ``search-results-returned``, you can do the following::
+
+    (smallest (histogram reg "search-results-returned"))
     => 4
 
 .. _histograms/largest:
@@ -157,6 +179,11 @@ histogram::
     (largest search-results-returned)
     => 1345
 
+Or if you haven't held a reference to ``search-results-returned``, you can do the following::
+
+    (largest (histogram reg "search-results-returned"))
+    => 1345
+
 .. _histograms/mean:
 
 ``mean``
@@ -170,6 +197,11 @@ histogram::
     (mean search-results-returned)
     => 233.12
 
+Or if you haven't held a reference to ``search-results-returned``, you can do the following::
+
+    (mean (histogram reg "search-results-returned"))
+    => 233.12
+
 .. _histograms/std-dev:
 
 ``std-dev``
@@ -181,6 +213,11 @@ lifetime of this histogram::
     (require '[metrics.histograms :refer [std-dev]])
 
     (std-dev search-results-returned)
+    => 80.2
+
+Or if you haven't held a reference to ``search-results-returned``, you can do the following::
+
+    (std-dev (histogram reg "search-results-returned"))
     => 80.2
 
 .. _histograms/sample:
@@ -197,4 +234,9 @@ know what you're doing.
     (require '[metrics.histograms :refer [sample]])
 
     (sample search-results-returned)
+    => [12 2232 234 122]
+
+Or if you haven't held a reference to ``search-results-returned``, you can do the following::
+
+    (sample (histogram reg "search-results-returned"))
     => [12 2232 234 122]

--- a/docs/source/metrics/meters.rst
+++ b/docs/source/metrics/meters.rst
@@ -32,10 +32,12 @@ Create your meter::
     (require '[metrics.meters :refer [meter]])
 
     (def reg (new-registry))
-    (def files-served (meter reg "files-served" "files"))
+    (def files-served (meter reg "files-served"))
 
-The second argument to ``meter`` is a string describing the "units" for the
-meter.  In this example it's "files", as in "18732 files".
+The ``meter`` function is idempotent, which means that you don't
+need to keep a local reference to the meter. Once a meter has been
+registered, a call to ``(meter reg "files-served")`` will return
+the existing meter.
 
 .. _meters/defmeter:
 
@@ -44,7 +46,7 @@ in one concise, easy step::
 
     (require '[metrics.meters :refer (defmeter)])
 
-    (defmeter reg files-served "files")
+    (defmeter reg files-served)
 
 All the ``def[metric]`` macros do some :ref:`magic <desugaring>` to the metric
 title to make it easier to define.
@@ -64,6 +66,10 @@ Mark the meter every time the event happens with ``mark!``::
     (require '[metrics.meters :refer [mark!]])
 
     (mark! files-served)
+
+Or if you haven't held a reference to ``files-served``, you can do the following::
+
+    (mark! (meter reg "files-served"))
 
 Reading
 -------
@@ -103,6 +109,11 @@ If you only care about the rate of events during the last minute you can use
     (rate-one files-served)
     => 100.0
 
+Or if you haven't held a reference to ``files-served``, you can do the following::
+
+    (rate-one (meter reg "files-served"))
+    => 100.0
+
 .. _meters/rate-five:
 
 ``rate-five``
@@ -114,6 +125,11 @@ use ``rate-five``::
     (require '[metrics.meters :refer [rate-five]])
 
     (rate-five files-served)
+    => 120.0
+
+Or if you haven't held a reference to ``files-served``, you can do the following::
+
+    (rate-five (meter reg "files-served"))
     => 120.0
 
 .. _meters/rate-fifteen:
@@ -129,6 +145,11 @@ can use ``rate-fifteen``::
     (rate-fifteen files-served)
     => 76.0
 
+Or if you haven't held a reference to ``files-served``, you can do the following::
+
+    (rate-fifteen (meter reg "files-served"))
+    => 76.0
+
 .. _meters/rate-mean:
 
 ``rate-mean``
@@ -140,4 +161,9 @@ you probably don't) you can use ``rate-mean``::
     (require '[metrics.meters :refer [rate-mean]])
 
     (rate-mean files-served)
+    => 204.123
+
+Or if you haven't held a reference to ``files-served``, you can do the following::
+
+    (rate-mean (meter reg "files-served"))
     => 204.123

--- a/docs/source/metrics/timers.rst
+++ b/docs/source/metrics/timers.rst
@@ -22,6 +22,11 @@ Create your timer::
 
     (def image-processing-time (timer "image-processing-time"))
 
+The ``timer`` function is idempotent, which means that you don't need
+to keep a local reference to the timer. Once a timer has been
+registered, a call to ``(timer reg "image-processing-time")`` will
+return the existing timer.
+
 .. _timers/deftimer:
 
 You can also use the ``deftimer`` macro to create a timer and bind it to a var
@@ -49,6 +54,12 @@ You can record the time it takes to evaluate one or more expressions with the ``
     (require '[metrics.timers :refer [time!]])
 
     (time! image-processing-time
+           (process-image-part-1 ...)
+           (process-image-part-2 ...))
+
+Or if you haven't held a reference to ``image-processing-time``, you can do the following::
+
+    (time! (timer reg "image-processing-time")
            (process-image-part-1 ...)
            (process-image-part-2 ...))
 

--- a/metrics-clojure-core/src/metrics/counters.clj
+++ b/metrics-clojure-core/src/metrics/counters.clj
@@ -5,7 +5,8 @@
            java.util.concurrent.TimeUnit))
 
 (defn counter
-  "Create and return a new Counter metric with the given title.
+  "Create and return a new Counter metric with the given title. If a
+  Counter already exists with the given title, will return that Counter.
 
   Title can be a plain string like \"foo\" or a vector of three strings (group,
   type, and title) like:
@@ -68,4 +69,3 @@
   [^Counter c]
   (.dec c (.getCount c))
   c)
-

--- a/metrics-clojure-core/src/metrics/histograms.clj
+++ b/metrics-clojure-core/src/metrics/histograms.clj
@@ -5,11 +5,12 @@
 
 
 (defn histogram
-  "Create and return a Histogram metric with the given title.
+  "Create and return a Histogram metric with the given title. If a
+  Histogram already exists with the given title, will return that Histogram.
 
-  By default a biased Histogram is created.  This is probably what you want, but
-  if you know what you're doing you can pass false to create a uniform one
-  instead."
+  By default a biased Histogram is created.  This is probably what you
+  want. You cannot create an unbiased Histogram from this fn, you'll
+  need to look into the Java interop for that."
   ([title]
    (histogram default-registry title))
   ([^MetricRegistry reg title]
@@ -102,4 +103,3 @@
   [^Histogram h n]
   (.update h (long n))
   h)
-

--- a/metrics-clojure-core/src/metrics/meters.clj
+++ b/metrics-clojure-core/src/metrics/meters.clj
@@ -6,6 +6,15 @@
 
 
 (defn meter
+  "Create and return a new Meter metric with the given title. If a
+  Meter already exists with the given title, will return that Meter.
+
+  Title can be a plain string like \"foo\" or a vector of three strings (group,
+  type, and title) like:
+
+      [\"myapp\" \"webserver\" \"connections\"]
+
+  "
   ([title]
    (meter default-registry title))
   ([^MetricRegistry reg title]
@@ -66,4 +75,3 @@
   ([^Meter m n]
    (.mark m (long n))
    m))
-

--- a/metrics-clojure-core/src/metrics/timers.clj
+++ b/metrics-clojure-core/src/metrics/timers.clj
@@ -6,6 +6,15 @@
 
 
 (defn ^Timer timer
+  "Create and return a new Timer metric with the given title. If a
+  Timer already exists with the given title, will return that Timer.
+
+  Title can be a plain string like \"foo\" or a vector of three strings (group,
+  type, and title) like:
+
+      [\"myapp\" \"webserver\" \"connections\"]
+
+  "
   ([title]
    (timer default-registry title))
   ([^MetricRegistry reg title]


### PR DESCRIPTION
This reflects my current understanding, but please let me know if I'm mistaken.  Much of this is repetitive, but I think it's important to make sure people know there is an easy way to get-or-create a metric.

Note: removed following from meters.rst documentation: 

The second argument to `meter` is a string describing the "units" for the
meter.  In this example it's "files", as in "18732 files".

as it doesn't seem accurate from reading the code.

Note: removed following from histograms.rst documentation:

You can create an unbiased histogram by passing an extra boolean argument
(though you probably don't want to)::

(def search-results-returned-biased
     (histogram reg "search-results-returned-unbiased" false))

as it doesn't seem accurate from reading the code.
