### PR TITLE
deps.edn snapshots expects a map

### DIFF
--- a/metrics-clojure-core/deps.edn
+++ b/metrics-clojure-core/deps.edn
@@ -24,9 +24,9 @@
  :mvn/repos
  {"sonatype"
   {:url "http://oss.sonatype.org/content/repositories/releases",
-   :snapshots false,
+   :snapshots {:enabled false},
    :releases {:checksum :fail, :update :always}},
   "sonatype-snapshots"
   {:url "http://oss.sonatype.org/content/repositories/snapshots",
-   :snapshots true,
+   :snapshots {:enabled true},
    :releases {:checksum :fail, :update :always}}}}


### PR DESCRIPTION
See https://clojure.org/reference/deps_edn#procurer_mvn_repos_snapshots

With latest clojure I'm getting this error:
```
Error building classpath. Error reading deps ~/.gitlibs/libs/metrics-clojure/metrics-clojure/532fc437e734b049a54cb9a198f201dc5f47328e/metrics-clojure-core/deps.edn. Found: false, expected: map?
```
